### PR TITLE
Refactor: Separate PDF Generation and Twig Rendering Responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,17 @@ cd resumecraft
 composer install
 ```
 
-4. Customize your resume data by editing the data.json file located in the project root. You can structure your resume data as per the provided template.
+## Customize your resume
+you can customize your resume data by editing the data.json file located in the project root. You can structure your resume data as per the provided template.
+
+Please note that there are several templates available by default, based on Twig, with names matching the keys in the `data.json` file.
+
+* If you wish to remove one of the built-in resume sections, simply delete the corresponding key from the `data.json` file.
+* If you want to change the order of sections, you can rearrange the corresponding keys in the `data.json` file.
+* If you'd like to add a new template, simply create a Twig file in the `templates` directory with the same name as the corresponding key in `data.json`. The filename, without the '.twig' extension, should match the key in `data.json`.
+
+This flexibility allows you to customize your resume by modifying the data and templates according to your preferences.
+
 
 ## Usage
 

--- a/src/PDFEngine.php
+++ b/src/PDFEngine.php
@@ -6,14 +6,17 @@ use Mpdf\Config\ConfigVariables;
 use Mpdf\Config\FontVariables;
 use Mpdf\HTMLParserMode;
 use Mpdf\Mpdf;
+use Mpdf\MpdfException;
 use Mpdf\Output\Destination;
 
 class PDFEngine
 {
     private Mpdf $mpdf;
-    private array $PDFMeta;
     const PROJECT_ROOT = __DIR__ . '/..'; // Define the constant for the root directory
 
+    /**
+     * @throws MpdfException
+     */
     public function __construct()
     {
         // Initialize Mpdf with custom configurations
@@ -49,6 +52,12 @@ class PDFEngine
         ]);
     }
 
+    /**
+     * @param $metadata
+     * @param $htmlContent
+     * @return void
+     * @throws MpdfException
+     */
     public function __invoke($metadata, $htmlContent)
     {
         // Load CSS stylesheet and resume data from JSON file

--- a/src/PDFEngine.php
+++ b/src/PDFEngine.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ResumeCraft;
+
+use Mpdf\Config\ConfigVariables;
+use Mpdf\Config\FontVariables;
+use Mpdf\HTMLParserMode;
+use Mpdf\Mpdf;
+use Mpdf\Output\Destination;
+
+class PDFEngine
+{
+    private Mpdf $mpdf;
+    private array $PDFMeta;
+    const PROJECT_ROOT = __DIR__ . '/..'; // Define the constant for the root directory
+
+    public function __construct()
+    {
+        // Initialize Mpdf with custom configurations
+        $defaultConfig = (new ConfigVariables())->getDefaults();
+        $fontDirs = $defaultConfig['fontDir'];
+
+        $defaultFontConfig = (new FontVariables())->getDefaults();
+        $fontData = $defaultFontConfig['fontdata'];
+
+        $this->mpdf = new Mpdf([
+            'tempDir' => self::PROJECT_ROOT . '/cache/',
+            'margin_left' => 0,
+            'margin_right' => 0,
+            'margin_top' => 0,
+            'margin_bottom' => 0,
+            'margin_header' => 0,
+            'margin_footer' => 0,
+            'fontDir' => array_merge($fontDirs, [
+                self::PROJECT_ROOT . '/resources/fonts/',
+            ]),
+            'fontdata' => $fontData + [
+                    'nunito' => [
+                        'R' => 'NunitoSans-Regular.ttf',
+                        'I' => 'NunitoSans-ExpandedBlack.ttf',
+                        'B' => 'NunitoSans-ExtraBold.ttf',
+                        'BI' => 'NunitoSans-ExtraBoldItalic.ttf'
+                    ],
+                    'customicons' => [
+                        'R' => 'CustomIconsForResume.ttf'
+                    ]
+                ],
+            'default_font' => 'nunito'
+        ]);
+    }
+
+    public function __invoke($metadata, $htmlContent)
+    {
+        // Load CSS stylesheet and resume data from JSON file
+        $stylesheet = file_get_contents(self::PROJECT_ROOT . '/resources/css/style.css');
+
+
+        // Set metadata for the PDF document
+        $this->mpdf->setTitle($metadata['pdfTitle']);
+        $this->mpdf->setAuthor($metadata['pdfAuthor']);
+        $this->mpdf->setCreator($metadata['pdfCreator']);
+        $this->mpdf->setSubject($metadata['pdfSubject']);
+        $this->mpdf->setKeywords($metadata['pdfKeywords']);
+
+        // Write HTML content to the PDF
+        $this->mpdf->WriteHTML($stylesheet, HTMLParserMode::HEADER_CSS);
+        $this->mpdf->WriteHTML($htmlContent, HTMLParserMode::HTML_BODY);
+
+        // Output the generated PDF
+        $this->mpdf->Output('resumecraft.pdf', Destination::INLINE);
+    }
+}

--- a/src/TemplateEngine.php
+++ b/src/TemplateEngine.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ResumeCraft;
+
+use Mpdf\Tag\Th;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+class TemplateEngine
+{
+    const PROJECT_ROOT = __DIR__ . '/..'; // Define the constant for the root directory
+
+
+    /**
+     * @return Environment
+     */
+    public function twig(): Environment
+    {
+        $loader = new FilesystemLoader($this->getTemplatesPath());
+        return new Environment($loader, [
+            'cache' => false, // Set to '../cache/' if you want to use cache
+        ]);
+    }
+
+    /**
+     * @return string
+     */
+    private function getTemplatesPath(): string
+    {
+        return self::PROJECT_ROOT . '/resources/templates';
+    }
+
+    public function getTemplateList() : array
+    {
+        return array_diff(scandir($this->getTemplatesPath()), array('.', '..'));
+    }
+}

--- a/src/TemplateEngine.php
+++ b/src/TemplateEngine.php
@@ -2,14 +2,12 @@
 
 namespace ResumeCraft;
 
-use Mpdf\Tag\Th;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
 class TemplateEngine
 {
     const PROJECT_ROOT = __DIR__ . '/..'; // Define the constant for the root directory
-
 
     /**
      * @return Environment
@@ -30,6 +28,9 @@ class TemplateEngine
         return self::PROJECT_ROOT . '/resources/templates';
     }
 
+    /**
+     * @return array
+     */
     public function getTemplateList() : array
     {
         return array_diff(scandir($this->getTemplatesPath()), array('.', '..'));


### PR DESCRIPTION
In this PR, i've implemented a significant refactoring to improve code organization and adhere to SOLID principles. The main changes include:

1. **Separation of Concerns:** We've separated the responsibilities for PDF generation and Twig HTML rendering into distinct classes to adhere to the Single Responsibility Principle (SRP) of SOLID.

2. **Introducing PDFEngine.php:** The newly created `PDFEngine.php` class is now responsible for handling all PDF generation tasks. This separation allows us to manage PDF-related logic independently and promotes maintainability.

3. **Introducing TemplateEngine.php:** The `TemplateEngine.php` class is introduced to handle Twig HTML rendering. This separation ensures that the rendering of Twig templates is isolated from other functionalities.

By breaking down our code into more focused classes, we not only improve readability and maintainability but also make it easier to extend and modify each component without affecting the others. This commit sets the foundation for a more robust and scalable codebase.
